### PR TITLE
画像データ投稿を画像なしでも投稿できるようにした

### DIFF
--- a/db/migrate/20210709064739_devise_create_users.rb
+++ b/db/migrate/20210709064739_devise_create_users.rb
@@ -32,10 +32,10 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       # t.string   :unlock_token # Only if unlock strategy is :email or :both
       # t.datetime :locked_at
       
-      t.string :last_name, null:false
-      t.string :first_name, null:false
-      t.string :last_name_kana, null:false
-      t.string :first_name_kana, null:false
+      t.string :last_name,                null:false
+      t.string :first_name,               null:false
+      t.string :last_name_kana,           null:false
+      t.string :first_name_kana,          null:false
       t.integer :prefectures, default: 0, null: false
 
       t.timestamps null: false

--- a/db/migrate/20210710010546_create_post_images.rb
+++ b/db/migrate/20210710010546_create_post_images.rb
@@ -2,7 +2,7 @@ class CreatePostImages < ActiveRecord::Migration[5.2]
   def change
     create_table :post_images do |t|
       t.integer :user_id,     null: false
-      t.string  :image_id,    null: false
+      t.string  :image_id
       t.string  :description
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,7 +29,7 @@ ActiveRecord::Schema.define(version: 2021_07_10_012546) do
 
   create_table "post_images", force: :cascade do |t|
     t.integer "user_id", null: false
-    t.string "image_id", null: false
+    t.string "image_id"
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Post_imagesのマイグレーションファイルを訂正した。
image_idをnull falseにしており、画像データがなければ新規投稿が出来なかった為、今回変更した。